### PR TITLE
ProductDetailsResponse last_used Type Date instead of Datetime

### DIFF
--- a/pygrocy/grocy_api_client.py
+++ b/pygrocy/grocy_api_client.py
@@ -145,7 +145,7 @@ class ProductBarcodeData(BaseModel):
 
 class ProductDetailsResponse(BaseModel):
     last_purchased: Optional[date] = None
-    last_used: Optional[datetime] = None
+    last_used: Optional[date] = None
     stock_amount: int
     stock_amount_opened: int
     next_best_before_date: Optional[date] = None


### PR DESCRIPTION
## Description

When using datetime for last_used, the following validation error is returned.

pydantic.error_wrappers.ValidationError: 1 validation error for ProductDetailsResponse
last_used
  invalid datetime format (type=value_error.datetime)

The used_date Column is set to Type DATE:
        used_date DATE,

## Checklist
  - [x] The code change is tested and works locally.
  - [x] tests pass. **Your PR won't be merged unless tests pass**
  - [x] There is no commented out code in this PR
