### PR TITLE
Added support for product quantities

### DIFF
--- a/pygrocy/data_models/product.py
+++ b/pygrocy/data_models/product.py
@@ -10,6 +10,7 @@ from pygrocy.grocy_api_client import (
     ProductBarcodeData,
     ProductData,
     ProductDetailsResponse,
+    QuantityUnitData,
     ShoppingListItem,
     StockLogResponse,
 )
@@ -23,6 +24,28 @@ class ProductBarcode(DataModel):
     def barcode(self) -> str:
         return self._barcode
 
+class QuantityUnit(DataModel):
+    def __init__(self, data: QuantityUnitData):
+        self._id = data.id
+        self._name = data.name
+        self._name_plural = data.name_plural
+        self._description = data.description
+
+    @property
+    def id(self) -> int:
+        return self._id
+    
+    @property
+    def name(self) -> str:
+        return self._name
+    
+    @property
+    def name_plural(self) -> str:
+        return self._name_plural
+
+    @property
+    def description(self) -> str:
+        return self._description
 
 class Product(DataModel):
     def __init__(self, data):
@@ -47,6 +70,9 @@ class Product(DataModel):
         self._available_amount = None
         self._best_before_date = None
 
+        self._default_quantity_unit_purchase = None
+        self._qu_factor_purchase_to_stock = None
+
         self._barcodes = []
         self._product_group_id = None
 
@@ -68,6 +94,7 @@ class Product(DataModel):
         self._available_amount = response.stock_amount
         self._best_before_date = response.next_best_before_date
         self._barcodes = [ProductBarcode(data) for data in response.barcodes]
+        self._default_quantity_unit_purchase = QuantityUnit(response.default_quantity_unit_purchase)
 
         if response.product:
             self._init_from_ProductData(response.product)
@@ -76,6 +103,7 @@ class Product(DataModel):
         self._id = product.id
         self._product_group_id = product.product_group_id
         self._name = product.name
+        self._qu_factor_purchase_to_stock = product.qu_factor_purchase_to_stock
 
     def _init_from_StockLogResponse(self, response: StockLogResponse):
         self._id = response.product_id
@@ -123,6 +151,14 @@ class Product(DataModel):
     @property
     def is_partly_in_stock(self) -> int:
         return self._is_partly_in_stock
+    
+    @property
+    def default_quantity_unit_purchase(self) -> QuantityUnit:
+        return self._default_quantity_unit_purchase
+
+    @property
+    def qu_factor_purchase_to_stock(self) -> float:
+        return self._qu_factor_purchase_to_stock
 
 
 class Group(DataModel):

--- a/pygrocy/data_models/product.py
+++ b/pygrocy/data_models/product.py
@@ -24,6 +24,7 @@ class ProductBarcode(DataModel):
     def barcode(self) -> str:
         return self._barcode
 
+
 class QuantityUnit(DataModel):
     def __init__(self, data: QuantityUnitData):
         self._id = data.id
@@ -34,11 +35,11 @@ class QuantityUnit(DataModel):
     @property
     def id(self) -> int:
         return self._id
-    
+
     @property
     def name(self) -> str:
         return self._name
-    
+
     @property
     def name_plural(self) -> str:
         return self._name_plural
@@ -46,6 +47,7 @@ class QuantityUnit(DataModel):
     @property
     def description(self) -> str:
         return self._description
+
 
 class Product(DataModel):
     def __init__(self, data):
@@ -94,7 +96,9 @@ class Product(DataModel):
         self._available_amount = response.stock_amount
         self._best_before_date = response.next_best_before_date
         self._barcodes = [ProductBarcode(data) for data in response.barcodes]
-        self._default_quantity_unit_purchase = QuantityUnit(response.default_quantity_unit_purchase)
+        self._default_quantity_unit_purchase = QuantityUnit(
+            response.default_quantity_unit_purchase
+        )
 
         if response.product:
             self._init_from_ProductData(response.product)
@@ -151,7 +155,7 @@ class Product(DataModel):
     @property
     def is_partly_in_stock(self) -> int:
         return self._is_partly_in_stock
-    
+
     @property
     def default_quantity_unit_purchase(self) -> QuantityUnit:
         return self._default_quantity_unit_purchase

--- a/pygrocy/grocy.py
+++ b/pygrocy/grocy.py
@@ -243,10 +243,10 @@ class Grocy(object):
         return self._api_client.add_missing_product_to_shopping_list(shopping_list_id)
 
     def add_product_to_shopping_list(
-        self, product_id: int, shopping_list_id: int = None, amount: int = None
+        self, product_id: int, shopping_list_id: int = None, amount: int = None, quantity_unit_id: int = None
     ):
         return self._api_client.add_product_to_shopping_list(
-            product_id, shopping_list_id, amount
+            product_id, shopping_list_id, amount, quantity_unit_id
         )
 
     def clear_shopping_list(self, shopping_list_id: int = 1):

--- a/pygrocy/grocy.py
+++ b/pygrocy/grocy.py
@@ -243,7 +243,11 @@ class Grocy(object):
         return self._api_client.add_missing_product_to_shopping_list(shopping_list_id)
 
     def add_product_to_shopping_list(
-        self, product_id: int, shopping_list_id: int = None, amount: int = None, quantity_unit_id: int = None
+        self,
+        product_id: int,
+        shopping_list_id: int = None,
+        amount: int = None,
+        quantity_unit_id: int = None,
     ):
         return self._api_client.add_product_to_shopping_list(
             product_id, shopping_list_id, amount, quantity_unit_id

--- a/pygrocy/grocy_api_client.py
+++ b/pygrocy/grocy_api_client.py
@@ -534,7 +534,11 @@ class GrocyApiClient(object):
         self._do_post_request("stock/shoppinglist/add-missing-products", data)
 
     def add_product_to_shopping_list(
-        self, product_id: int, shopping_list_id: int = 1, amount: int = 1, quantity_unit_id: int = None
+        self,
+        product_id: int,
+        shopping_list_id: int = 1,
+        amount: int = 1,
+        quantity_unit_id: int = None,
     ):
         data = {
             "product_id": product_id,

--- a/pygrocy/grocy_api_client.py
+++ b/pygrocy/grocy_api_client.py
@@ -152,6 +152,7 @@ class ProductDetailsResponse(BaseModel):
     last_price: Optional[float] = None
     product: ProductData
     quantity_unit_stock: QuantityUnitData
+    default_quantity_unit_purchase: QuantityUnitData
     barcodes: Optional[List[ProductBarcodeData]] = Field(alias="product_barcodes")
     location: Optional[LocationData] = None
 
@@ -533,13 +534,16 @@ class GrocyApiClient(object):
         self._do_post_request("stock/shoppinglist/add-missing-products", data)
 
     def add_product_to_shopping_list(
-        self, product_id: int, shopping_list_id: int = 1, amount: int = 1
+        self, product_id: int, shopping_list_id: int = 1, amount: int = 1, quantity_unit_id: int = None
     ):
         data = {
             "product_id": product_id,
             "list_id": shopping_list_id,
             "product_amount": amount,
         }
+        if quantity_unit_id:
+            data["qu_id"] = quantity_unit_id
+        print(data)
         self._do_post_request("stock/shoppinglist/add-product", data)
 
     def clear_shopping_list(self, shopping_list_id: int = 1):

--- a/test/test_product.py
+++ b/test/test_product.py
@@ -23,6 +23,11 @@ class TestProduct:
         assert product.name == "Cheese"
         assert product.available_amount == 5
         assert product.product_group_id == 6
+        assert product.qu_factor_purchase_to_stock == 1.0
+        assert product.default_quantity_unit_purchase.id == 3
+        assert product.default_quantity_unit_purchase.name == "Pack"
+        assert product.default_quantity_unit_purchase.description == None
+        assert product.default_quantity_unit_purchase.name_plural == "Packs"
 
         assert len(product.product_barcodes) == 1
         barcode = product.product_barcodes[0]


### PR DESCRIPTION
## Description

As I want to use pygrocy to add new items to the shopping list, I was missing the support to handle quantities of products. Therefore, I made following two changes:

1. Added support to QuantityUnit in the product data model. This is filled with quantity information of products.
2. Added the field qu_factor_purchase_to_stock of a product to get the default conversion rate for adding items to the shopping list.
3. Extended the add_product_to_shopping_list function to support a different quantity unit.
4. Extended tests to cover above changes (if applicable)

**Related issue (if applicable):** 
n/a

## Checklist
  - [x] The code change is tested and works locally.
  - [x] tests pass. **Your PR won't be merged unless tests pass**
  - [x] There is no commented out code in this PR
