### PR TITLE
Add subproduct substution to consume_product

### DIFF
--- a/pygrocy/grocy.py
+++ b/pygrocy/grocy.py
@@ -148,9 +148,10 @@ class Grocy(object):
         amount: float = 1,
         spoiled: bool = False,
         transaction_type: TransactionType = TransactionType.CONSUME,
+        allow_subproduct_substitution: bool = False,
     ):
         return self._api_client.consume_product(
-            product_id, amount, spoiled, transaction_type
+            product_id, amount, spoiled, transaction_type, allow_subproduct_substitution
         )
 
     def inventory_product(

--- a/pygrocy/grocy_api_client.py
+++ b/pygrocy/grocy_api_client.py
@@ -411,7 +411,7 @@ class GrocyApiClient(object):
             "amount": amount,
             "spoiled": spoiled,
             "transaction_type": transaction_type.value,
-            "allow_subproduct_substitution": allow_subproduct_substitution
+            "allow_subproduct_substitution": allow_subproduct_substitution,
         }
 
         self._do_post_request(f"stock/products/{product_id}/consume", data)

--- a/pygrocy/grocy_api_client.py
+++ b/pygrocy/grocy_api_client.py
@@ -405,11 +405,13 @@ class GrocyApiClient(object):
         amount: float = 1,
         spoiled: bool = False,
         transaction_type: TransactionType = TransactionType.CONSUME,
+        allow_subproduct_substitution: bool = False,
     ):
         data = {
             "amount": amount,
             "spoiled": spoiled,
             "transaction_type": transaction_type.value,
+            "allow_subproduct_substitution": allow_subproduct_substitution
         }
 
         self._do_post_request(f"stock/products/{product_id}/consume", data)


### PR DESCRIPTION
## Description

This adds another optional argument for the `consume_product` endpoint to allow subproduct substitution. Without this, you cannot consume subproducts of a parent product through pygrocy:

```py
from pygrocy import Grocy
from pygrocy.grocy_api_client import TransactionType

grocy = Grocy("http://10.0.0.10", "xxx", port = 6666, verify_ssl = False)

grocy.consume_product(
    product_id=154, # Parent product with no stock, but suitable subproducts in stock
    amount=1,
    spoiled=False,
    transaction_type=TransactionType.CONSUME,
    allow_subproduct_substitution=True
)
```

**Related issue (if applicable):** fixes #220 

## Checklist
  - [x] The code change is tested and works locally.
  - [x] tests pass. **Your PR won't be merged unless tests pass**
  - [x] There is no commented out code in this PR
