### PR TITLE
Fix parsing API responses with empty str or null values for optional fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 `pip install pygrocy`
 
 ## Usage
-Import the package: 
+Import the package:
 ```python
 from pygrocy import Grocy
 ```
@@ -38,4 +38,4 @@ for entry in grocy.stock():
 If you need help using pygrocy check the [discussions](https://github.com/SebRut/pygrocy/issues) section. Feel free to create an issue for feature requests, bugs and errors in the library.
 
 ## Development testing
-You need tox and Python 3.6/8/9 to run the tests. Navigate to the root dir of `pygrocy` and execute `tox` to run the tests.
+You need tox and Python 3.8/9/10 to run the tests. Navigate to the root dir of `pygrocy` and execute `tox` to run the tests.

--- a/pygrocy/grocy_api_client.py
+++ b/pygrocy/grocy_api_client.py
@@ -3,11 +3,11 @@ import json
 import logging
 from datetime import datetime
 from enum import Enum
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Any
 from urllib.parse import urljoin
 
 import requests
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
 from pydantic.schema import date
 
 from pygrocy import EntityType
@@ -19,6 +19,17 @@ DEFAULT_PORT_NUMBER = 9192
 
 _LOGGER = logging.getLogger(__name__)
 _LOGGER.setLevel(logging.INFO)
+
+
+def _field_not_empty_validator(field_name: str):
+    """Reusable Pydantic field pre-validator to convert empty str to None."""
+    return validator(field_name, allow_reuse=True, pre=True)(_none_if_empty_str)
+
+
+def _none_if_empty_str(value: Any):
+    if isinstance(value, str) and value == "":
+        return None
+    return value
 
 
 class ShoppingListItem(BaseModel):
@@ -76,7 +87,7 @@ class ProductData(BaseModel):
     id: int
     name: str
     description: Optional[str] = None
-    location_id: int
+    location_id: Optional[int] = None
     product_group_id: Optional[int] = None
     qu_id_stock: int
     qu_id_purchase: int
@@ -86,6 +97,9 @@ class ProductData(BaseModel):
     row_created_timestamp: datetime
     min_stock_amount: Optional[float]
     default_best_before_days: int
+
+    location_id_validator = _field_not_empty_validator("location_id")
+    product_group_id_validator = _field_not_empty_validator("product_group_id")
 
 
 class ChoreData(BaseModel):
@@ -102,6 +116,10 @@ class ChoreData(BaseModel):
     next_execution_assigned_to_user_id: Optional[int] = None
     userfields: Optional[Dict]
 
+    next_execution_assigned_to_user_id_validator = _field_not_empty_validator(
+        "next_execution_assigned_to_user_id"
+    )
+
 
 class UserDto(BaseModel):
     id: int
@@ -113,8 +131,8 @@ class UserDto(BaseModel):
 
 class CurrentChoreResponse(BaseModel):
     chore_id: int
-    last_tracked_time: Optional[datetime]
-    next_estimated_execution_time: datetime
+    last_tracked_time: Optional[datetime] = None
+    next_estimated_execution_time: Optional[datetime] = None
 
 
 class CurrentStockResponse(BaseModel):
@@ -160,7 +178,7 @@ class ProductDetailsResponse(BaseModel):
 class ChoreDetailsResponse(BaseModel):
     chore: ChoreData
     last_tracked: Optional[datetime] = None
-    next_estimated_execution_time: datetime
+    next_estimated_execution_time: Optional[datetime] = None
     track_count: int = 0
     next_execution_assigned_user: Optional[UserDto] = None
     last_done_by: Optional[UserDto] = None
@@ -193,11 +211,14 @@ class TaskResponse(BaseModel):
     assigned_to_user: Optional[UserDto] = None
     userfields: Optional[Dict] = None
 
+    category_id_validator = _field_not_empty_validator("category_id")
+    assigned_to_user_id_validator = _field_not_empty_validator("assigned_to_user_id")
+
 
 class CurrentBatteryResponse(BaseModel):
     id: int
     last_tracked_time: Optional[datetime] = None
-    next_estimated_charge_time: datetime
+    next_estimated_charge_time: Optional[datetime] = None
 
 
 class BatteryData(BaseModel):
@@ -214,7 +235,7 @@ class BatteryDetailsResponse(BaseModel):
     battery: BatteryData
     charge_cycles_count: int
     last_charged: Optional[datetime] = None
-    next_estimated_charge_time: datetime
+    next_estimated_charge_time: Optional[datetime] = None
 
 
 class MealPlanSectionResponse(BaseModel):
@@ -222,6 +243,8 @@ class MealPlanSectionResponse(BaseModel):
     name: str
     sort_number: Optional[int] = None
     row_created_timestamp: datetime
+
+    sort_number_validator = _field_not_empty_validator("sort_number")
 
 
 class StockLogResponse(BaseModel):
@@ -617,7 +640,7 @@ class GrocyApiClient(object):
             return RecipeDetailsResponse(**parsed_json)
 
     def get_batteries(self) -> List[CurrentBatteryResponse]:
-        parsed_json = self._do_get_request(f"batteries")
+        parsed_json = self._do_get_request("batteries")
         if parsed_json:
             return [CurrentBatteryResponse(**data) for data in parsed_json]
 

--- a/test/test_product.py
+++ b/test/test_product.py
@@ -26,7 +26,7 @@ class TestProduct:
         assert product.qu_factor_purchase_to_stock == 1.0
         assert product.default_quantity_unit_purchase.id == 5
         assert product.default_quantity_unit_purchase.name == "Tin"
-        assert product.default_quantity_unit_purchase.description == None
+        assert product.default_quantity_unit_purchase.description is None
         assert product.default_quantity_unit_purchase.name_plural == "Tins"
 
         assert len(product.product_barcodes) == 2


### PR DESCRIPTION
## Description

The API can return value "" in the json response for the optional fields: _product_group_id_, _location_id_, _category_id_, _next_execution_assigned_to_user_id_, _assigned_to_user_id_, _sort_number_ and _location_id_. It can return null for the chores field _next_estimated_execution_time_ and battery field _next_estimated_charge_time_.
All resulted in an exception before, while parsing the json.

Changes:
- None is now returned for mentioned fields if value is "", so the str to int cast Pydantic does won't fail.
- The shopping list item field _location_id_ can also be empty and is optional now.
- The mentioned datetime fields are optional now.
- Existing flake8 warnings resolved.

**Related issue (if applicable):**

Fixes:
https://github.com/SebRut/pygrocy/issues/215

https://github.com/SebRut/pygrocy/issues/203

https://github.com/custom-components/grocy/issues/191

https://github.com/custom-components/grocy/issues/192

https://github.com/custom-components/grocy/issues/184

https://github.com/custom-components/grocy/issues/183

https://github.com/custom-components/grocy/issues/179

https://github.com/custom-components/grocy/pull/172#issuecomment-1021644619

## Checklist
  - [x] The code change is tested and works locally.
  - [x] tests pass. **Your PR won't be merged unless tests pass**
  - [x] There is no commented out code in this PR
