### PR TITLE
Fix for optional task due_date, category and user

### DIFF
--- a/pygrocy/data_models/task.py
+++ b/pygrocy/data_models/task.py
@@ -40,9 +40,11 @@ class Task(DataModel):
         self._done = response.done
         self._done_timestamp = response.done_timestamp
         self._category_id = response.category_id
+        self._category = None
         if response.category:
             self._category = TaskCategory(response.category)
         self._assigned_to_user_id = response.assigned_to_user_id
+        self._assigned_to_user = None
         if response.assigned_to_user:
             self._assigned_to_user = User(response.assigned_to_user)
         self._userfields = response.userfields

--- a/pygrocy/grocy_api_client.py
+++ b/pygrocy/grocy_api_client.py
@@ -202,7 +202,7 @@ class TaskResponse(BaseModel):
     id: int
     name: str
     description: Optional[str] = None
-    due_date: date = None
+    due_date: Optional[date] = None
     done: int
     done_timestamp: Optional[datetime] = None
     category_id: Optional[int] = None
@@ -211,6 +211,7 @@ class TaskResponse(BaseModel):
     assigned_to_user: Optional[UserDto] = None
     userfields: Optional[Dict] = None
 
+    due_date_validator = _field_not_empty_validator("due_date")
     category_id_validator = _field_not_empty_validator("category_id")
     assigned_to_user_id_validator = _field_not_empty_validator("assigned_to_user_id")
 


### PR DESCRIPTION
## Description

Changes:
- Return None for task _due_date_ empty str (optional field).
- Return empty __category_ and __assigned_to_user_ field for task, if not set in the response. Otherwise it causes an exception.

**Related issue (if applicable):** fixes #<issue number goes here>

## Checklist
  - [x] The code change is tested and works locally.
  - [x] tests pass. **Your PR won't be merged unless tests pass**
  - [x] There is no commented out code in this PR
