### PR TITLE
Fix int type for amount and price floats

### DIFF
--- a/pygrocy/grocy.py
+++ b/pygrocy/grocy.py
@@ -157,11 +157,11 @@ class Grocy(object):
     def inventory_product(
         self,
         product_id: int,
-        new_amount: int,
+        new_amount: float,
         best_before_date: datetime = None,
         shopping_location_id: int = None,
         location_id: int = None,
-        price: int = None,
+        price: float = None,
         get_details: bool = True,
     ) -> Product:
         product = Product(
@@ -215,10 +215,10 @@ class Grocy(object):
     def inventory_product_by_barcode(
         self,
         barcode: str,
-        new_amount: int,
+        new_amount: float,
         best_before_date: datetime = None,
         location_id: int = None,
-        price: int = None,
+        price: float = None,
         get_details: bool = True,
     ) -> Product:
         product = Product(
@@ -247,7 +247,7 @@ class Grocy(object):
         self,
         product_id: int,
         shopping_list_id: int = None,
-        amount: int = None,
+        amount: float = None,
         quantity_unit_id: int = None,
     ):
         return self._api_client.add_product_to_shopping_list(
@@ -258,7 +258,7 @@ class Grocy(object):
         return self._api_client.clear_shopping_list(shopping_list_id)
 
     def remove_product_in_shopping_list(
-        self, product_id: int, shopping_list_id: int = 1, amount: int = 1
+        self, product_id: int, shopping_list_id: int = 1, amount: float = 1
     ):
         return self._api_client.remove_product_in_shopping_list(
             product_id, shopping_list_id, amount

--- a/pygrocy/grocy_api_client.py
+++ b/pygrocy/grocy_api_client.py
@@ -164,8 +164,8 @@ class ProductBarcodeData(BaseModel):
 class ProductDetailsResponse(BaseModel):
     last_purchased: Optional[date] = None
     last_used: Optional[date] = None
-    stock_amount: int
-    stock_amount_opened: int
+    stock_amount: float
+    stock_amount_opened: float
     next_best_before_date: Optional[date] = None
     last_price: Optional[float] = None
     product: ProductData
@@ -251,7 +251,7 @@ class MealPlanSectionResponse(BaseModel):
 class StockLogResponse(BaseModel):
     id: int
     product_id: int
-    amount: int
+    amount: float
     best_before_date: date
     purchased_date: date
     used_date: Optional[date] = None
@@ -447,7 +447,7 @@ class GrocyApiClient(object):
         best_before_date: datetime = None,
         shopping_location_id: int = None,
         location_id: int = None,
-        price: int = None,
+        price: float = None,
     ):
         data = {
             "new_amount": new_amount,
@@ -523,7 +523,7 @@ class GrocyApiClient(object):
         new_amount: float,
         best_before_date: datetime = None,
         location_id: int = None,
-        price: int = None,
+        price: float = None,
     ):
         data = {
             "new_amount": new_amount,
@@ -563,7 +563,7 @@ class GrocyApiClient(object):
         self,
         product_id: int,
         shopping_list_id: int = 1,
-        amount: int = 1,
+        amount: float = 1,
         quantity_unit_id: int = None,
     ):
         data = {
@@ -581,7 +581,7 @@ class GrocyApiClient(object):
         self._do_post_request("stock/shoppinglist/clear", data)
 
     def remove_product_in_shopping_list(
-        self, product_id: int, shopping_list_id: int = 1, amount: int = 1
+        self, product_id: int, shopping_list_id: int = 1, amount: float = 1
     ):
         data = {
             "product_id": product_id,


### PR DESCRIPTION
## Description

Fields and parameters mentioned below are of type int, but Grocy can hold float values. This causes an exception.

- Class _ProductDetailsResponse_ fields: _stock_amount_, _stock_amount_opened_
- Class _StockLogResponse_, field: _amount_
- Methods _inventory_product_, _inventory_product_by_barcode_, parameters: _price_, _new_amount_
- Methods _add_product_to_shopping_list_, _clear_shopping_list_, parameter: _amount_

Changed type from int to float.

**Related issue (if applicable):** fixes #<issue number goes here>

## Checklist
  - [x] The code change is tested and works locally.
  - [x] tests pass. **Your PR won't be merged unless tests pass**
  - [x] There is no commented out code in this PR
