### PR TITLE
Fix tzlocal dependency causing an exception

### DIFF
--- a/pygrocy/utils.py
+++ b/pygrocy/utils.py
@@ -1,14 +1,10 @@
 from datetime import datetime
 
-import iso8601
-import pytz
-from tzlocal import get_localzone
-
 
 def parse_date(input_value):
     if input_value == "" or input_value is None:
         return None
-    return iso8601.parse_date(input_value)
+    return datetime.fromisoformat(input_value)
 
 
 def parse_int(input_value, default_value=None):
@@ -40,8 +36,4 @@ def parse_bool_int(input_value):
 
 
 def localize_datetime(timestamp: datetime) -> datetime:
-    if timestamp.tzinfo is not None:
-        return timestamp
-
-    local_tz = get_localzone()
-    return local_tz.localize(timestamp).astimezone(pytz.utc)
+    return timestamp.astimezone()

--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         "requests",
-        "iso8601>=0.1.16,<1.1.0",
-        "pytz>=2021.1,<2023.0",
-        "tzlocal>=2.1,<5.0",
+        "backports.zoneinfo",  # backports can be removed when python 3.8 support is dropped
         "deprecation~=2.1.0",
         "pydantic>=1.8.2,<1.10.0",
     ],

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,12 +1,17 @@
 from datetime import datetime
-from unittest import TestCase
+
+try:
+    import zoneinfo
+except ImportError:
+    # backports can be removed when python 3.8 support is dropped
+    from backports import zoneinfo
 
 import pygrocy.utils as utils
 
 
-class TestUtils(TestCase):
+class TestUtils:
     def test_parse_date_valid(self):
-        date_str = "2019-05-04T11:31:04.563Z"
+        date_str = "2022-07-10 21:10:53"
         date_obj = utils.parse_date(date_str)
 
         assert isinstance(date_obj, datetime)
@@ -58,3 +63,37 @@ class TestUtils(TestCase):
         float_number = utils.parse_float(float_str, -1)
 
         assert float_number == -1
+
+    def test_localize_datetime_input_timezone_unaware(self):
+        date = datetime(2022, 7, 10, 21, 17, 34, 633809, tzinfo=None)
+
+        localized_datetime = utils.localize_datetime(date)
+
+        assert localized_datetime == datetime(
+            2022, 7, 10, 21, 17, 34, 633809, tzinfo=zoneinfo.ZoneInfo("localtime")
+        )
+
+    def test_localize_datetime_input_timezone_aware(self):
+        date = datetime(
+            2022,
+            7,
+            10,
+            13,
+            17,
+            34,
+            633809,
+            tzinfo=zoneinfo.ZoneInfo("America/Los_Angeles"),
+        )
+
+        localized_datetime = utils.localize_datetime(date)
+
+        assert localized_datetime == datetime(
+            2022,
+            7,
+            10,
+            13,
+            17,
+            34,
+            633809,
+            tzinfo=zoneinfo.ZoneInfo("America/Los_Angeles"),
+        )


### PR DESCRIPTION
## Description

Some users have an issue with the `localize_datetime` method, as reported in https://github.com/custom-components/grocy/issues/241.
This seems to be related to an issues with `tzlocal` `get_localzone` returning different types, see https://github.com/regebro/tzlocal/issues/131.

Some existing dependencies, including `tzlocal`, can be replaced with Python built-in functions.

- Remove `pytz` and `tzlocal` dependencies and use Python built-in function.

- The `localize_datetime` method is inconsistent. For timezone aware datetime, it returns the datetime as is. For timezone unaware datetime, it assumes it is in the system's local timezone and returns it converted to UTC.
Change method so it also returns a localized datetime when the specified datetime is timezone unaware.

- Replace `iso8601` dependency with Python built-in function. Change test to match the datetime string format returned by the Grocy API.

## Checklist
  - [x] The code change is tested and works locally.
  - [x] tests pass. **Your PR won't be merged unless tests pass**
  - [x] There is no commented out code in this PR
