### PR TITLE
Fix tracking time for chores, tasks and batteries

### DIFF
--- a/pygrocy/grocy.py
+++ b/pygrocy/grocy.py
@@ -125,7 +125,7 @@ class Grocy(object):
         self,
         chore_id: int,
         done_by: int = None,
-        tracked_time: datetime = datetime.now(),
+        tracked_time: datetime = None,
         skipped: bool = False,
     ):
         return self._api_client.execute_chore(chore_id, done_by, tracked_time, skipped)
@@ -326,7 +326,7 @@ class Grocy(object):
         resp = self._api_client.get_task(task_id)
         return Task(resp)
 
-    def complete_task(self, task_id, done_time: datetime = datetime.now()):
+    def complete_task(self, task_id, done_time: datetime = None):
         return self._api_client.complete_task(task_id, done_time)
 
     def meal_plan(
@@ -361,7 +361,7 @@ class Grocy(object):
         if battery:
             return Battery(battery)
 
-    def charge_battery(self, battery_id: int, tracked_time: datetime = datetime.now()):
+    def charge_battery(self, battery_id: int, tracked_time: datetime = None):
         return self._api_client.charge_battery(battery_id, tracked_time)
 
     def add_generic(self, entity_type: EntityType, data):

--- a/pygrocy/grocy_api_client.py
+++ b/pygrocy/grocy_api_client.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, Extra, Field, root_validator, validator
 from pydantic.schema import date
 
 from pygrocy import EntityType
-from pygrocy.utils import localize_datetime, parse_date
+from pygrocy.utils import grocy_datetime_str, localize_datetime, parse_date
 
 from .errors import GrocyError
 
@@ -453,13 +453,16 @@ class GrocyApiClient(object):
         self,
         chore_id: int,
         done_by: int = None,
-        tracked_time: datetime = datetime.now(),
+        tracked_time: datetime = None,
         skipped: bool = False,
     ):
+        if tracked_time is None:
+            tracked_time = datetime.now()
+
         localized_tracked_time = localize_datetime(tracked_time)
 
         data = {
-            "tracked_time": localized_tracked_time.isoformat(),
+            "tracked_time": grocy_datetime_str(localized_tracked_time),
             "skipped": skipped,
         }
 
@@ -733,12 +736,15 @@ class GrocyApiClient(object):
         parsed_json = self._do_get_request(url)
         return TaskResponse(**parsed_json)
 
-    def complete_task(self, task_id: int, done_time: datetime = datetime.now()):
+    def complete_task(self, task_id: int, done_time: datetime = None):
         url = f"tasks/{task_id}/complete"
+
+        if done_time is None:
+            done_time = datetime.now()
 
         localized_done_time = localize_datetime(done_time)
 
-        data = {"done_time": localized_done_time.isoformat()}
+        data = {"done_time": grocy_datetime_str(localized_done_time)}
         self._do_post_request(url, data)
 
     def get_meal_plan(self, query_filters: List[str] = None) -> List[MealPlanResponse]:
@@ -765,9 +771,12 @@ class GrocyApiClient(object):
         if parsed_json:
             return BatteryDetailsResponse(**parsed_json)
 
-    def charge_battery(self, battery_id: int, tracked_time: datetime = datetime.now()):
+    def charge_battery(self, battery_id: int, tracked_time: datetime = None):
+        if tracked_time is None:
+            tracked_time = datetime.now()
+
         localized_tracked_time = localize_datetime(tracked_time)
-        data = {"tracked_time": localized_tracked_time.isoformat()}
+        data = {"tracked_time": grocy_datetime_str(localized_tracked_time)}
 
         return self._do_post_request(f"batteries/{battery_id}/charge", data)
 

--- a/pygrocy/utils.py
+++ b/pygrocy/utils.py
@@ -37,3 +37,9 @@ def parse_bool_int(input_value):
 
 def localize_datetime(timestamp: datetime) -> datetime:
     return timestamp.astimezone()
+
+
+def grocy_datetime_str(timestamp: datetime) -> str:
+    if timestamp is None:
+        return ""
+    return timestamp.strftime("%Y-%m-%d %H:%M:%S")

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -97,3 +97,9 @@ class TestUtils:
             633809,
             tzinfo=zoneinfo.ZoneInfo("America/Los_Angeles"),
         )
+
+    def test_grocy_datetime_str(self):
+        date = datetime(2022, 7, 10, 21, 17, 34, 633809, tzinfo=None)
+        date_str = utils.grocy_datetime_str(date)
+
+        assert date_str == "2022-07-10 21:17:34"


### PR DESCRIPTION
## Description

Fix incorrect tracking time for chores, tasks and batteries.

- The Grocy API expects a string datetime for `tracked_time` in the format 2022-09-24 18:00:00. It ignores other time formats (and replace it with Grocy `local_time`).

- Default function parameters are evaluated only once. So the `datetime.now()` is not being updated for successive calls. Change the default value to None and set `datetime.now()` in the function body.
 
**Related issue (if applicable):** fixes #254 

## Checklist
  - [x] The code change is tested and works locally.
  - [x] tests pass. **Your PR won't be merged unless tests pass**
  - [x] There is no commented out code in this PR
