### PR TITLE
Convert empty value to None for qu_factor_purchase_to_stock

### DIFF
--- a/pygrocy/grocy_api_client.py
+++ b/pygrocy/grocy_api_client.py
@@ -91,7 +91,7 @@ class ProductData(BaseModel):
     product_group_id: Optional[int] = None
     qu_id_stock: int
     qu_id_purchase: int
-    qu_factor_purchase_to_stock: float
+    qu_factor_purchase_to_stock: Optional[float] = None
     picture_file_name: Optional[str] = None
     allow_partial_units_in_stock: Optional[bool] = False
     row_created_timestamp: datetime
@@ -100,6 +100,9 @@ class ProductData(BaseModel):
 
     location_id_validator = _field_not_empty_validator("location_id")
     product_group_id_validator = _field_not_empty_validator("product_group_id")
+    qu_factor_purchase_to_stock_validator = _field_not_empty_validator(
+        "qu_factor_purchase_to_stock"
+    )
 
 
 class ChoreData(BaseModel):


### PR DESCRIPTION
## Description

With Grocy 3.3.2, casting the value for field _qu_factor_purchase_to_stock_ throws an exception in some cases. This change converts an empty value to None to avoid float casting errors.

**Related issue (if applicable):** fixes #<issue number goes here>

https://github.com/custom-components/grocy/issues/257

## Checklist
  - [x] The code change is tested and works locally.
  - [x] tests pass. **Your PR won't be merged unless tests pass**
  - [x] There is no commented out code in this PR
