### PR TITLE
Remove qu_factor_purchase_to_stock to maintain compatibility with API v4

### DIFF
--- a/pygrocy/data_models/product.py
+++ b/pygrocy/data_models/product.py
@@ -77,7 +77,6 @@ class Product(DataModel):
         self._best_before_date = None
 
         self._default_quantity_unit_purchase = None
-        self._qu_factor_purchase_to_stock = None
 
         self._barcodes = []
         self._product_group_id = None
@@ -115,7 +114,6 @@ class Product(DataModel):
         self._id = product.id
         self._product_group_id = product.product_group_id
         self._name = product.name
-        self._qu_factor_purchase_to_stock = product.qu_factor_purchase_to_stock
 
     def _init_from_StockLogResponse(self, response: StockLogResponse):
         self._id = response.product_id
@@ -183,10 +181,6 @@ class Product(DataModel):
     @property
     def default_quantity_unit_purchase(self) -> QuantityUnit:
         return self._default_quantity_unit_purchase
-
-    @property
-    def qu_factor_purchase_to_stock(self) -> float:
-        return self._qu_factor_purchase_to_stock
 
 
 class Group(DataModel):

--- a/pygrocy/data_models/task.py
+++ b/pygrocy/data_models/task.py
@@ -32,7 +32,6 @@ class TaskCategory(DataModel):
 
 class Task(DataModel):
     def __init__(self, response: TaskResponse):
-
         self._id = response.id
         self._name = response.name
         self._description = response.description

--- a/pygrocy/grocy_api_client.py
+++ b/pygrocy/grocy_api_client.py
@@ -91,7 +91,6 @@ class ProductData(BaseModel):
     product_group_id: Optional[int] = None
     qu_id_stock: int
     qu_id_purchase: int
-    qu_factor_purchase_to_stock: Optional[float] = None
     picture_file_name: Optional[str] = None
     allow_partial_units_in_stock: Optional[bool] = False
     row_created_timestamp: datetime
@@ -100,8 +99,6 @@ class ProductData(BaseModel):
 
     location_id_validator = _field_not_empty_validator("location_id")
     product_group_id_validator = _field_not_empty_validator("product_group_id")
-    qu_factor_purchase_to_stock_validator = _field_not_empty_validator(
-        "qu_factor_purchase_to_stock"
     )
 
 

--- a/pygrocy/grocy_api_client.py
+++ b/pygrocy/grocy_api_client.py
@@ -99,7 +99,6 @@ class ProductData(BaseModel):
 
     location_id_validator = _field_not_empty_validator("location_id")
     product_group_id_validator = _field_not_empty_validator("product_group_id")
-    )
 
 
 class ChoreData(BaseModel):

--- a/test/test_product.py
+++ b/test/test_product.py
@@ -23,7 +23,6 @@ class TestProduct:
         assert product.name == "Gulash soup"
         assert product.available_amount == 5
         assert product.product_group_id == 3
-        assert product.qu_factor_purchase_to_stock == 1.0
         assert product.default_quantity_unit_purchase.id == 5
         assert product.default_quantity_unit_purchase.name == "Tin"
         assert product.default_quantity_unit_purchase.description is None


### PR DESCRIPTION
## Description

According to the [changelog](https://grocy.info/changelog), v4.0.0 introduced a breaking change by removing `qu_factor_purchase_to_stock` from the `/products/{productId}` endpoint. I'm proposing to remove the field and the associated validator to allow updated installations to be compatible. 

This does not add the new fields under the `/products/{productId}` but fixes requests for Product data in updated installations.

## Checklist
  - [x] The code change is tested and works locally.
  - [x] tests pass. **Your PR won't be merged unless tests pass**
  - [x] There is no commented out code in this PR