### PR TITLE
Make plural name optional for Quantity Units

### DIFF
--- a/pygrocy/grocy_api_client.py
+++ b/pygrocy/grocy_api_client.py
@@ -71,7 +71,7 @@ class RecipeDetailsResponse(BaseModel):
 class QuantityUnitData(BaseModel):
     id: int
     name: str
-    name_plural: str
+    name_plural: Optional[str] = None
     description: Optional[str] = None
     row_created_timestamp: datetime
 


### PR DESCRIPTION
## Description

Makes the plural name of the Quantity Unit optional. 

**Related issue (if applicable):** fixes #271 

## Checklist
  - [X] The code change is tested and works locally.
  - [X] tests pass. **Your PR won't be merged unless tests pass**
  - [X] There is no commented out code in this PR
