### PR TITLE
use value prop in delete API call

### DIFF
--- a/pygrocy/grocy.py
+++ b/pygrocy/grocy.py
@@ -373,7 +373,7 @@ class Grocy(object):
         )
 
     def delete_generic(self, entity_type: EntityType, object_id: int):
-        return self._api_client.delete_generic(entity_type, object_id)
+        return self._api_client.delete_generic(entity_type.value, object_id)
 
     def get_generic_objects_for_type(
         self, entity_type: EntityType, query_filters: List[str] = None


### PR DESCRIPTION
## Description

I noticed the `delete_generic` method was throwing a 400 in Home Assistant. After investigating, it appears that the `value` property is used in other methods whereas it is not for `delete_generic`.  This PR uses the `value` property of the passed in `entity_type` and allows for successful deletion of non-task entities (chores).

## Checklist
  - [X] The code change is tested and works locally.
  - [X] tests pass. **Your PR won't be merged unless tests pass**
  - [X] There is no commented out code in this PR
